### PR TITLE
Fixing typo in MacrosExample Explode README.md

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Explode/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/README.md
@@ -12,7 +12,7 @@ The `Explode` macro provides a template-wide `Explode` property for CloudFormati
 
 ```shell
 aws cloudformation package \
-    --template-file macro.yaml \
+    --template-file macro.yml \
     --s3-bucket <your bucket name here> \
     --output-template-file packaged.yaml
 ```


### PR DESCRIPTION
Changing macro.yaml --> macro.yml becase the actual file is called macro.yml.